### PR TITLE
Implement smooth scrolling for navbar links, restoring home on privac…

### DIFF
--- a/js/spa.js
+++ b/js/spa.js
@@ -64,6 +64,7 @@ document.addEventListener('DOMContentLoaded', function () {
   // Handle navbar links - restore home if on privacy/terms pages
   document.querySelectorAll('a[href^="#"]:not(.spa-link)').forEach(link => {
     link.addEventListener('click', function (e) {
+      const SCROLL_DELAY_MS = 100;
       // If we're currently on privacy or terms page, restore home first
       if (window.location.hash === '#privacy' || window.location.hash === '#terms') {
         e.preventDefault();
@@ -78,7 +79,7 @@ document.addEventListener('DOMContentLoaded', function () {
               behavior: 'smooth'
             });
           }
-        }, 100);
+        }, SCROLL_DELAY_MS);
       }
     });
   });

--- a/js/spa.js
+++ b/js/spa.js
@@ -74,9 +74,9 @@ document.addEventListener('DOMContentLoaded', function () {
           const targetId = this.getAttribute('href');
           const targetElement = document.querySelector(targetId);
           if (targetElement) {
-            window.scrollTo({
-              top: targetElement.offsetTop - 80,
-              behavior: 'smooth'
+            targetElement.scrollIntoView({
+              behavior: 'smooth',
+              block: 'start'
             });
           }
         }, SCROLL_DELAY_MS);

--- a/js/spa.js
+++ b/js/spa.js
@@ -61,6 +61,28 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   });
 
+  // Handle navbar links - restore home if on privacy/terms pages
+  document.querySelectorAll('a[href^="#"]:not(.spa-link)').forEach(link => {
+    link.addEventListener('click', function (e) {
+      // If we're currently on privacy or terms page, restore home first
+      if (window.location.hash === '#privacy' || window.location.hash === '#terms') {
+        e.preventDefault();
+        restoreHome();
+        // Then scroll to the target section after a short delay
+        setTimeout(() => {
+          const targetId = this.getAttribute('href');
+          const targetElement = document.querySelector(targetId);
+          if (targetElement) {
+            window.scrollTo({
+              top: targetElement.offsetTop - 80,
+              behavior: 'smooth'
+            });
+          }
+        }, 100);
+      }
+    });
+  });
+
   // Listen for hash changes
   window.addEventListener('hashchange', handleHash);
 


### PR DESCRIPTION
This pull request introduces a new feature to improve navigation behavior in the single-page application (SPA). Specifically, it ensures that when users click on navbar links while on the privacy or terms pages, the application first restores the home view before smoothly scrolling to the target section.

### Navigation behavior improvements:
* [`js/spa.js`](diffhunk://#diff-8f729e82fbe45d64b942a857625d976b4049d89d8e1a253f89cdf3f342e287f0R64-R86): Added an event listener for non-SPA navbar links (`a[href^="#"]:not(.spa-link)`) to handle clicks. If the user is on the privacy or terms page, the application prevents the default behavior, restores the home view using `restoreHome()`, and then scrolls to the target section with a smooth animation after a short delay.This pull request adds functionality to improve navigation behavior in the single-page application (`js/spa.js`). Specifically, it ensures that when users click on navbar links while on the privacy or terms pages, the application first restores the home view before scrolling to the target section.